### PR TITLE
Running fluentd without supervisor mode

### DIFF
--- a/src/main/scala/xerial/fluentd/FluentdStandalone.scala
+++ b/src/main/scala/xerial/fluentd/FluentdStandalone.scala
@@ -85,7 +85,7 @@ class FluentdStandalone(val config:FluentdConfig) extends Logger {
     prepare(config)
 
     info(s"Starting fluentd")
-    val process = Shell.launchProcess(s"${config.fluentdCmd} -c ${config.getConfigFile}")
+    val process = Shell.launchProcess(s"${config.fluentdCmd} -c ${config.getConfigFile} --no-supervisor")
     fluentdProcess = Some(process)
     val t = new Thread(new Runnable {
       def run() {


### PR DESCRIPTION
On travis CI, fluentd's supervisor tries to restart a fluentd worker after executing tests: it results in test failure because of timeout.
https://travis-ci.org/fluent/fluent-logger-scala/jobs/188810280

No supervisor option seems to be suitable to avoid the situation.
http://www.fluentd.org/blog/fluentd-v0.10.57-is-released